### PR TITLE
feat: strict type for phpstan

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -17,6 +17,16 @@ use Queryflatfile\Exception\TableBuilder\TableBuilderException;
  * Pattern fluent pour la création et configuration des types de données.
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
+ *
+ * @phpstan-type FieldToArray array{
+ *      _comment?: string,
+ *      default?: null|scalar,
+ *      length?: int,
+ *      nullable?: bool,
+ *      opt?: string,
+ *      type: string,
+ *      unsigned?: bool,
+ * }
  */
 abstract class Field
 {
@@ -33,7 +43,7 @@ abstract class Field
     protected const INVALID_ARGUMENT_MESSAGE = 'The value of the %s field must be of type %s: %s given.';
 
     /**
-     * @var bool|null|numeric|string
+     * @var null|scalar
      */
     protected $valueDefault;
 
@@ -92,11 +102,11 @@ abstract class Field
      * Enregistre une valeur par défaut au champ précédent.
      * Lève une exception si la valeur par défaut ne correspond pas au type de valeur passée en paramètre.
      *
-     * @param bool|null|numeric|string $value Valeur à tester.
+     * @param null|scalar $value Valeur à tester.
      *
      * @throws ColumnsValueException
      *
-     * @return bool|null|numeric|string
+     * @return null|scalar
      */
     abstract public function filterValue($value);
 
@@ -104,7 +114,7 @@ abstract class Field
      * Enregistre une valeur par défaut au champ précédent.
      * Lève une exception si la valeur par défaut ne correspond pas au type de valeur passée en paramètre.
      *
-     * @param bool|null|numeric|string $value Valeur à tester.
+     * @param null|scalar $value Valeur à tester.
      *
      * @throws TableBuilderException
      *
@@ -122,7 +132,7 @@ abstract class Field
      *
      * @throws ColumnsValueException
      *
-     * @return bool|null|numeric|string Valeur par defaut.
+     * @return null|scalar Valeur par defaut.
      */
     public function getValueDefault()
     {
@@ -178,14 +188,12 @@ abstract class Field
     /**
      * Retourne les données du champ.
      *
-     * @return array
+     * @return FieldToArray
      */
     public function toArray(): array
     {
-        $data = [];
-        if (static::TYPE !== '') {
-            $data[ 'type' ] = static::TYPE;
-        }
+        $data[ 'type' ] = static::TYPE;
+
         if ($this->isNullable) {
             $data[ 'nullable' ] = $this->isNullable;
         }

--- a/src/Field.php
+++ b/src/Field.php
@@ -188,7 +188,9 @@ abstract class Field
     /**
      * Retourne les données du champ.
      *
-     * @return FieldToArray
+     * @return array
+     *
+     * @phpstan-return FieldToArray
      */
     public function toArray(): array
     {

--- a/src/Field/StringType.php
+++ b/src/Field/StringType.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 
 namespace Queryflatfile\Field;
 
-use Queryflatfile\Field;
-
 /**
  * @author Mathieu NOËL <mathieu@soosyze.com>
  */

--- a/src/Request.php
+++ b/src/Request.php
@@ -38,7 +38,9 @@ class Request extends RequestHandler
     /**
      * Les données de la table.
      *
-     * @var TableData
+     * @var array
+     *
+     * @phpstan-var TableData
      */
     private $tableData = [];
 
@@ -186,7 +188,9 @@ class Request extends RequestHandler
     /**
      * Retourne tous les résultats de la requête.
      *
-     * @return TableData les données
+     * @return array les données
+     *
+     * @phpstan-return TableData
      */
     public function fetchAll(): array
     {
@@ -271,7 +275,9 @@ class Request extends RequestHandler
     /**
      * Retourne le premier résultat de la requête.
      *
-     * @return RowData Résultat de la requête.
+     * @return array Résultat de la requête.
+     *
+     * @phpstan-return RowData
      */
     public function fetch(): array
     {

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -87,14 +87,18 @@ abstract class RequestHandler implements RequestInterface
     /**
      * Les jointures à calculer.
      *
-     * @var Join[]
+     * @var array
+     *
+     * @phpstan-var Join[]
      */
     protected $joins = [];
 
     /**
      * Les unions.
      *
-     * @var Union[]
+     * @var array
+     *
+     * @phpstan-var Union[]
      */
     protected $unions = [];
 
@@ -136,7 +140,9 @@ abstract class RequestHandler implements RequestInterface
     /**
      * Les valeurs à insérer ou mettre à jour.
      *
-     * @var TableData
+     * @var array
+     *
+     * @phpstan-var TableData
      */
     protected $values = [];
 

--- a/src/RequestHandler.php
+++ b/src/RequestHandler.php
@@ -17,30 +17,30 @@ use BadMethodCallException;
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
  *
- * @method Request where(string $column, string $operator, null|scalar $value)      Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request notWhere(string $column, string $operator, null|scalar $value)   Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orWhere(string $column, string $operator, null|scalar $value)    Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orNotWhere(string $column, string $operator, null|scalar $value) Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request where(string $columnName, string $operator, null|scalar $value)      Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request notWhere(string $columnName, string $operator, null|scalar $value)   Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orWhere(string $columnName, string $operator, null|scalar $value)    Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orNotWhere(string $columnName, string $operator, null|scalar $value) Alias de la fonction de l'objet Queryflatfile\Where
  *
- * @method Request between(string $column, numeric|string $min, numeric|string $max)      Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orBetween(string $column, numeric|string $min, numeric|string $max)    Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request notBetween(string $column, numeric|string $min, numeric|string $max)   Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orNotBetween(string $column, numeric|string $min, numeric|string $max) Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request between(string $columnName, numeric|string $min, numeric|string $max)      Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orBetween(string $columnName, numeric|string $min, numeric|string $max)    Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request notBetween(string $columnName, numeric|string $min, numeric|string $max)   Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orNotBetween(string $columnName, numeric|string $min, numeric|string $max) Alias de la fonction de l'objet Queryflatfile\Where
  *
- * @method Request in(string $column, array $values)      Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orIn(string $column, array $values)    Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request notIn(string $column, array $values)   Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orNotIn(string $column, array $values) Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request in(string $columnName, array $values)      Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orIn(string $columnName, array $values)    Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request notIn(string $columnName, array $values)   Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orNotIn(string $columnName, array $values) Alias de la fonction de l'objet Queryflatfile\Where
  *
- * @method Request isNull(string $column)      Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orIsNull(string $column)    Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request isNotNull(string $column)   Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orIsNotNull(string $column) Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request isNull(string $columnName)      Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orIsNull(string $columnName)    Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request isNotNull(string $columnName)   Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orIsNotNull(string $columnName) Alias de la fonction de l'objet Queryflatfile\Where
  *
- * @method Request regex(string $column, string $pattern)      Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orRegex(string $column, string $pattern)    Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request notRegex(string $column, string $pattern)   Alias de la fonction de l'objet Queryflatfile\Where
- * @method Request orNotRegex(string $column, string $pattern) Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request regex(string $columnName, string $pattern)      Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orRegex(string $columnName, string $pattern)    Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request notRegex(string $columnName, string $pattern)   Alias de la fonction de l'objet Queryflatfile\Where
+ * @method Request orNotRegex(string $columnName, string $pattern) Alias de la fonction de l'objet Queryflatfile\Where
  *
  * @method Request whereGroup(\Closure $callable)      Alias de la fonction de l'objet Queryflatfile\Where
  * @method Request notWhereGroup(\Closure $callable)   Alias de la fonction de l'objet Queryflatfile\Where
@@ -135,7 +135,7 @@ abstract class RequestHandler implements RequestInterface
      *
      * @var string[]
      */
-    protected $columns = [];
+    protected $columnNames = [];
 
     /**
      * Les valeurs à insérer ou mettre à jour.
@@ -202,18 +202,18 @@ abstract class RequestHandler implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumns(): array
+    public function getColumnNames(): array
     {
-        return $this->columns;
+        return $this->columnNames;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function insertInto(string $tableName, array $columns)
+    public function insertInto(string $tableName, array $columnNames)
     {
         $this->execute = self::INSERT;
-        $this->from($tableName)->select(...$columns);
+        $this->from($tableName)->select(...$columnNames);
 
         return $this;
     }
@@ -248,9 +248,9 @@ abstract class RequestHandler implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function orderBy(string $column, int $order = SORT_ASC)
+    public function orderBy(string $columnName, int $order = SORT_ASC)
     {
-        $this->orderBy[ $column ] = $order;
+        $this->orderBy[ $columnName ] = $order;
 
         return $this;
     }
@@ -273,10 +273,10 @@ abstract class RequestHandler implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function select(string ...$columns)
+    public function select(string ...$columnNames)
     {
-        foreach ($columns as $column) {
-            $this->columns[] = $column;
+        foreach ($columnNames as $columnName) {
+            $this->columnNames[] = $columnName;
         }
 
         return $this;
@@ -305,11 +305,11 @@ abstract class RequestHandler implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function update(string $tableName, array $columns)
+    public function update(string $tableName, array $row)
     {
-        $this->execute   = self::UPDATE;
-        $this->from($tableName)->select(...array_keys($columns));
-        $this->values[ 0 ] = $columns;
+        $this->execute     = self::UPDATE;
+        $this->from($tableName)->select(...array_keys($row));
+        $this->values[ 0 ] = $row;
 
         return $this;
     }
@@ -317,9 +317,9 @@ abstract class RequestHandler implements RequestInterface
     /**
      * {@inheritdoc}
      */
-    public function values(array $columns)
+    public function values(array $rowValues)
     {
-        $this->values[] = $columns;
+        $this->values[] = $rowValues;
 
         return $this;
     }
@@ -331,16 +331,16 @@ abstract class RequestHandler implements RequestInterface
      */
     protected function init()
     {
-        $this->columns  = [];
-        $this->execute  = null;
-        $this->from     = '';
-        $this->joins    = [];
-        $this->limit    = self::ALL;
-        $this->offset   = 0;
-        $this->orderBy  = [];
-        $this->sumLimit = 0;
-        $this->unions   = [];
-        $this->values   = [];
+        $this->columnNames = [];
+        $this->execute     = null;
+        $this->from        = '';
+        $this->joins       = [];
+        $this->limit       = self::ALL;
+        $this->offset      = 0;
+        $this->orderBy     = [];
+        $this->sumLimit    = 0;
+        $this->unions      = [];
+        $this->values      = [];
 
         return $this;
     }
@@ -348,16 +348,16 @@ abstract class RequestHandler implements RequestInterface
     /**
      * Enregistre une jointure.
      *
-     * @param string $type      Type de la jointure.
-     * @param string $tableName Nom de la table à joindre
-     * @param string $column    Nom de la colonne d'une des tables précédentes.
-     * @param string $operator  Opérateur logique ou null pour une closure.
-     * @param string $value     Valeur ou une colonne de la table jointe (au format nom_table.colonne)
+     * @param string $type       Type de la jointure.
+     * @param string $tableName  Nom de la table à joindre
+     * @param string $columnName Nom de la colonne d'une des tables précédentes.
+     * @param string $operator   Opérateur logique ou null pour une closure.
+     * @param string $value      Valeur ou une colonne de la table jointe (au format nom_table.colonne)
      */
-    private function join(string $type, string $tableName, string $column, string $operator, string $value): void
+    private function join(string $type, string $tableName, string $columnName, string $operator, string $value): void
     {
         $where = new Where();
-        $where->where($column, $operator, $value);
+        $where->where($columnName, $operator, $value);
 
         $this->joins[] = [ 'type' => $type, 'table' => $tableName, 'where' => $where ];
     }

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -18,6 +18,7 @@ use Queryflatfile\Exception\TableBuilder\ColumnsNotFoundException;
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
 
+ * @phpstan-import-type RowValues from Schema
  * @phpstan-import-type RowData from Schema
  * @phpstan-import-type TableData from Schema
  */
@@ -47,16 +48,16 @@ interface RequestInterface
      * Enregistre les champs sélectionnées par la requête.
      * En cas d'absence de selection, la requêtes retournera toutes les champs.
      *
-     * @param string ...$columns Liste ou tableau des noms des colonnes.
+     * @param string ...$columnNames Liste ou tableau des noms des colonnes.
      *
      * @return $this
      */
-    public function select(string ...$columns);
+    public function select(string ...$columnNames);
 
     /**
      * @return string[]
      */
-    public function getColumns(): array;
+    public function getColumnNames(): array;
 
     /**
      * Enregistre le nom de la source des données principale de la requête.
@@ -71,7 +72,7 @@ interface RequestInterface
      * Enregistre une jointure gauche.
      *
      * @param string          $tableName Nom de la table à joindre.
-     * @param string|\Closure $column    Nom de la colonne d'une des tables précédentes
+     * @param string|\Closure $column    Nom de la colonne d'une des tables précédentes ou un group de condition
      *                                   ou une closure pour affiner les conditions.
      * @param string          $operator  Opérateur logique ou null pour une closure.
      * @param string          $value     Colonne de la table jointe (au format nom_table.colonne)
@@ -84,7 +85,7 @@ interface RequestInterface
      * Enregistre une jointure droite.
      *
      * @param string          $tableName Nom de la table à joindre
-     * @param string|\Closure $column    Nom de la colonne d'une des tables précédentes
+     * @param string|\Closure $column    Nom de la colonne d'une des tables précédentes ou un group de condition
      *                                   ou une closure pour affiner les conditions.
      * @param string          $operator  Opérateur logique ou null pour une closure.
      * @param string          $value     Colonne de la table jointe (au format nom_table.colonne)
@@ -106,46 +107,48 @@ interface RequestInterface
     /**
      * Enregistre un trie des résultats de la requête.
      *
-     * @param string $column Colonne à trier.
-     * @param int    $order  Ordre du trie (SORT_ASC|SORT_DESC).
+     * @param string $columnName Nom de la colonne à trier.
+     * @param int    $order      Ordre du trie (SORT_ASC|SORT_DESC).
      *
      * @return $this
      */
-    public function orderBy(string $column, int $order = SORT_ASC);
+    public function orderBy(string $columnName, int $order = SORT_ASC);
 
     /**
      * Enregistre l'action d'insertion de données.
      * Cette fonction doit-être suivie la fonction values().
      *
-     * @param string   $tableName Nom de la table.
-     * @param string[] $columns   Liste des champs par ordre d'insertion dans
-     *                            la fonction values().
+     * @param string   $tableName   Nom de la table.
+     * @param string[] $columnNames Liste des champs par ordre d'insertion dans
+     *                              la fonction values().
      *
      * @return $this
      */
-    public function insertInto(string $tableName, array $columns);
+    public function insertInto(string $tableName, array $columnNames);
 
     /**
      * Cette fonction doit suivre la fonction insertInto().
      * Les valeurs doivent suivre le même ordre que les clés précédemment enregistrées.
      *
-     * @param array<null|scalar> $columns Valeurs des champs.
+     * @param array $rowValues Valeurs des champs.
+     *
+     * @phpstan-param RowValues $rowValues
      *
      * @return $this
      */
-    public function values(array $columns);
+    public function values(array $rowValues);
 
     /**
      * Enregistre l'action de modification de données.
      *
      * @param string $tableName Nom de la table.
-     * @param array  $columns   key=>value des données à modifier.
+     * @param array  $row       key=>value des données à modifier.
      *
-     * @phpstan-param RowData $columns
+     * @phpstan-param RowData $row
      *
      * @return $this
      */
-    public function update(string $tableName, array $columns);
+    public function update(string $tableName, array $row);
 
     /**
      * Enregistre l'action de suppression des données.

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -138,8 +138,10 @@ interface RequestInterface
     /**
      * Enregistre l'action de modification de données.
      *
-     * @param string  $tableName Nom de la table.
-     * @param RowData $columns   key=>value des données à modifier.
+     * @param string $tableName Nom de la table.
+     * @param array  $columns   key=>value des données à modifier.
+     *
+     * @phpstan-param RowData $columns
      *
      * @return $this
      */
@@ -175,14 +177,18 @@ interface RequestInterface
     /**
      * Retourne tous les résultats de la requête.
      *
-     * @return TableData les données
+     * @return array les données
+     *
+     * @phpstan-return TableData
      */
     public function fetchAll(): array;
 
     /**
      * Retourne le premier résultat de la requête.
      *
-     * @return RowData Résultat de la requête.
+     * @return array Résultat de la requête.
+     *
+     * @phpstan-return RowData
      */
     public function fetch(): array;
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -27,6 +27,7 @@ use Queryflatfile\Field\RenameType;
  * @author Mathieu NOËL <mathieu@soosyze.com>
  *
  * @phpstan-type RowData array<string, null|scalar>
+ * @phpstan-type RowValues array<null|scalar>
  * @phpstan-type TableData RowData[]
  */
 class Schema
@@ -354,15 +355,15 @@ class Schema
     /**
      * Détermine si une colonne existe.
      *
-     * @param string $tableName Nom de la table.
-     * @param string $column    Nom de la colonne.
+     * @param string $tableName  Nom de la table.
+     * @param string $columnName Nom de la colonne.
      *
      * @return bool Si le schéma de référence et le fichier de données existent.
      */
-    public function hasColumn(string $tableName, string $column): bool
+    public function hasColumn(string $tableName, string $columnName): bool
     {
         return isset($this->getSchema()[ $tableName ]) &&
-            $this->getSchema()[ $tableName ]->hasField($column) &&
+            $this->getSchema()[ $tableName ]->hasField($columnName) &&
             $this->driver->has($this->root . $this->path, $tableName);
     }
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -489,9 +489,11 @@ class Schema
     /**
      * Ajoute un champ dans les paramètre de la table et ses données.
      *
-     * @param Table     $table     Schéma de la table.
-     * @param Field     $field     Nouveau champ.
-     * @param TableData $tableData Les données de la table.
+     * @param Table $table     Schéma de la table.
+     * @param Field $field     Nouveau champ.
+     * @param array $tableData Les données de la table.
+     *
+     * @phpstan-param TableData $tableData
      *
      * @return void
      */

--- a/src/Table.php
+++ b/src/Table.php
@@ -118,7 +118,9 @@ final class Table
     /**
      * Retourne les données de la table.
      *
-     * @return TableToArray
+     * @return array
+     *
+     * @phpstan-return TableToArray
      */
     public function toArray(): array
     {

--- a/src/Table.php
+++ b/src/Table.php
@@ -12,6 +12,16 @@ namespace Queryflatfile;
 
 use Queryflatfile\Field\IncrementType;
 
+/**
+ * @author Mathieu NOËL <mathieu@soosyze.com>
+ *
+ * @phpstan-import-type FieldToArray from Field
+ *
+ * @phpstan-type TableToArray array{
+ *      fields: array<string, FieldToArray>,
+ *      increments?: int|null
+ * }
+ */
 final class Table
 {
     /**
@@ -105,6 +115,11 @@ final class Table
         $this->increment = $increment;
     }
 
+    /**
+     * Retourne les données de la table.
+     *
+     * @return TableToArray
+     */
     public function toArray(): array
     {
         $fields = [];

--- a/src/TableBuilder.php
+++ b/src/TableBuilder.php
@@ -25,6 +25,8 @@ use Queryflatfile\Field\TextType;
  * Pattern fluent pour la création et configuration des types de données.
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
+ *
+ * @phpstan-import-type TableToArray from Table
  */
 class TableBuilder
 {
@@ -194,10 +196,11 @@ class TableBuilder
     /**
      * Créer une table à partir d'un tableau de données.
      *
-     * @param string $table Nom de la table.
-     * @param array  $data  Donnaées pour créer une table.
+     * @param string       $table Nom de la table.
+     * @param TableToArray $data  Donnaées pour créer une table.
      *
      * @throws TableBuilderException
+     *
      * @return Table
      */
     public static function createTableFromArray(string $table, array $data): Table

--- a/src/TableBuilder.php
+++ b/src/TableBuilder.php
@@ -196,8 +196,10 @@ class TableBuilder
     /**
      * Créer une table à partir d'un tableau de données.
      *
-     * @param string       $table Nom de la table.
-     * @param TableToArray $data  Donnaées pour créer une table.
+     * @param string $table Nom de la table.
+     * @param array  $data  Donnaées pour créer une table.
+     *
+     * @phpstan-param TableToArray $data
      *
      * @throws TableBuilderException
      *

--- a/src/Where.php
+++ b/src/Where.php
@@ -112,7 +112,9 @@ class Where extends WhereHandler
     /**
      * Retourne TRUE si la suite de condition enregistrée valide les champs du tableau.
      *
-     * @param RowData $row Tableau associatif de champ.
+     * @param array $row Tableau associatif de champ.
+     *
+     * @phpstan-param RowData $row
      *
      * @return bool
      */
@@ -152,8 +154,11 @@ class Where extends WhereHandler
      * Retourne TRUE si la suite de condition enregistrée valide les champs du tableau
      * par rapport à un autre tableau.
      *
-     * @param RowData $row      Tableau associatif de champ.
-     * @param RowData $rowTable Tableau associatif de champ à tester.
+     * @param array $row      Tableau associatif de champ.
+     * @param array $rowTable Tableau associatif de champ à tester.
+     *
+     * @phpstan-param RowData $row
+     * @phpstan-param RowData $rowTable
      *
      * @return bool
      */

--- a/src/Where.php
+++ b/src/Where.php
@@ -38,7 +38,7 @@ class Where extends WhereHandler
             $not = $where[ 'not' ]
                 ? 'NOT '
                 : '';
-            $whereColumn = $where[ 'column' ];
+            $whereColumn = $where[ 'columnName' ];
             switch ($where[ 'type' ]) {
                 case 'where':
                     $output .= sprintf('%s%s %s %s ', $not, addslashes($whereColumn), $where[ 'condition' ], self::getValueToString($where['value']));
@@ -89,21 +89,21 @@ class Where extends WhereHandler
     }
 
     /**
-     * Retourne toutes les colonnes utilisées pour créer la clause.
+     * Retourne les nom de toutes les colonnes utilisées pour créer la clause.
      *
      * @return string[] Colonnes.
      */
-    public function getColumns(): array
+    public function getColumnNames(): array
     {
         $output = [];
         foreach ($this->where as $value) {
-            if (isset($value[ 'columns' ])) {
-                $output = array_merge($output, $value[ 'columns' ]);
+            if (isset($value[ 'columnNames' ])) {
+                $output = array_merge($output, $value[ 'columnNames' ]);
 
                 continue;
             }
 
-            $output[] = self::getColumn($value[ 'column' ]);
+            $output[] = self::getColumn($value[ 'columnName' ]);
         }
 
         return $output;
@@ -126,7 +126,7 @@ class Where extends WhereHandler
             if ($value[ 'value' ] instanceof Where) {
                 $predicate = $value[ 'value' ]->execute($row);
             } else {
-                $predicate = self::predicate($row[ $value[ 'column' ] ], $value[ 'condition' ], $value[ 'value' ]);
+                $predicate = self::predicate($row[ $value[ 'columnName' ] ], $value[ 'condition' ], $value[ 'value' ]);
             }
             /* Si la clause est inversé. */
             if ($value[ 'not' ]) {
@@ -134,7 +134,7 @@ class Where extends WhereHandler
             }
             /* Les retours des types regex et like doivent être non null. */
             if ($value[ 'type' ] === 'regex' || $value[ 'type' ] === 'like') {
-                $predicate = $predicate && $row[ $value[ 'column' ] ] !== null;
+                $predicate = $predicate && $row[ $value[ 'columnName' ] ] !== null;
             }
 
             if ($key === 0) {
@@ -171,10 +171,10 @@ class Where extends WhereHandler
             if ($value[ 'value' ] instanceof Where) {
                 $predicate = $value[ 'value' ]->executeJoin($row, $rowTable);
             } else {
-                /** @var array{value:string, column: string, condition: string, bool:string} $value */
+                /** @var array{value:string, columnName: string, condition: string, bool:string} $value */
                 $val = $rowTable[ self::getColumn($value[ 'value' ]) ];
 
-                $predicate = self::predicate($row[ $value[ 'column' ] ], $value[ 'condition' ], $val);
+                $predicate = self::predicate($row[ $value[ 'columnName' ] ], $value[ 'condition' ], $val);
             }
 
             if ($key === 0) {
@@ -193,7 +193,7 @@ class Where extends WhereHandler
     /**
      * Retourne TRUE si la condition est validée.
      *
-     * @param null|scalar       $columns  Valeur à tester.
+     * @param null|scalar       $column   Valeur à tester.
      * @param string            $operator Condition à réaliser.
      * @param array|null|scalar $value    Valeur de comparaison.
      *
@@ -201,40 +201,40 @@ class Where extends WhereHandler
      *
      * @return bool
      */
-    protected static function predicate($columns, string $operator, $value): bool
+    protected static function predicate($column, string $operator, $value): bool
     {
         switch ($operator) {
             case '==':
-                return $columns == $value;
+                return $column == $value;
             case '=':
             case '===':
-                return $columns === $value;
+                return $column === $value;
             case '!==':
-                return $columns !== $value;
+                return $column !== $value;
             case '!=':
-                return $columns != $value;
+                return $column != $value;
             case '<>':
-                return $columns <> $value;
+                return $column <> $value;
             case '<':
-                return $columns < $value;
+                return $column < $value;
             case '<=':
-                return $columns <= $value;
+                return $column <= $value;
             case '>':
-                return $columns > $value;
+                return $column > $value;
             case '>=':
-                return $columns >= $value;
+                return $column >= $value;
             case 'in':
                 /** @var array $value */
-                return in_array($columns, $value);
+                return in_array($column, $value);
             case 'regex':
-                if ($columns === null) {
+                if ($column === null) {
                     return false;
                 }
                 /** @var string $value */
-                return preg_match($value, (string) $columns) === 1;
+                return preg_match($value, (string) $column) === 1;
             case 'between':
                 /** @var Between $value */
-                return $columns >= $value[ 'min' ] && $columns <= $value[ 'max' ];
+                return $column >= $value[ 'min' ] && $column <= $value[ 'max' ];
         }
 
         throw new OperatorNotFound(

--- a/src/WhereHandler.php
+++ b/src/WhereHandler.php
@@ -21,8 +21,8 @@ use Queryflatfile\Exception\Query\QueryException;
  * @phpstan-type Between array{min: numeric|string, max: numeric|string}
  * @phpstan-type WhereToArray array{
  *      bool: string,
- *      column: string,
- *      columns?: array,
+ *      columnName: string,
+ *      columnNames?: array,
  *      condition: string,
  *      not: bool,
  *      type: string,
@@ -62,16 +62,16 @@ class WhereHandler
      * Ajoute une condition simple pour la requête.
      * Si la valeur du champ est égal (non égale, supérieur à, ...)  par rapport à une valeur.
      *
-     * @param string      $column   Nom d'une colonne.
-     * @param string      $operator Type de condition.
-     * @param null|scalar $value    Valeur de teste.
-     * @param string      $bool     Porte logique de la condition (and|or).
-     * @param bool        $not      Inverse la condition.
+     * @param string      $columnName Nom d'une colonne.
+     * @param string      $operator   Type de condition.
+     * @param null|scalar $value      Valeur de teste.
+     * @param string      $bool       Porte logique de la condition (and|or).
+     * @param bool        $not        Inverse la condition.
      *
      * @throws OperatorNotFound The condition is not exist.
      */
     public function where(
-        string $column,
+        string $columnName,
         string $operator,
         $value,
         string $bool = self::EXP_AND,
@@ -84,7 +84,7 @@ class WhereHandler
                 throw new QueryException();
             }
             $this->like(
-                $column,
+                $columnName,
                 $condition,
                 $value,
                 $bool,
@@ -96,7 +96,7 @@ class WhereHandler
 
         $type = __FUNCTION__;
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
 
         return $this;
     }
@@ -106,9 +106,9 @@ class WhereHandler
      *
      * @param null|scalar $value Valeur de teste.
      */
-    public function notWhere(string $column, string $operator, $value): self
+    public function notWhere(string $columnName, string $operator, $value): self
     {
-        $this->where($column, $operator, $value, self::EXP_AND, true);
+        $this->where($columnName, $operator, $value, self::EXP_AND, true);
 
         return $this;
     }
@@ -118,9 +118,9 @@ class WhereHandler
      *
      * @param null|scalar $value Valeur de teste.
      */
-    public function orWhere(string $column, string $operator, $value): self
+    public function orWhere(string $columnName, string $operator, $value): self
     {
-        $this->where($column, $operator, $value, self::EXP_OR);
+        $this->where($columnName, $operator, $value, self::EXP_OR);
 
         return $this;
     }
@@ -130,9 +130,9 @@ class WhereHandler
      *
      * @param null|scalar $value Valeur de teste.
      */
-    public function orNotWhere(string $column, string $operator, $value): self
+    public function orNotWhere(string $columnName, string $operator, $value): self
     {
-        $this->where($column, $operator, $value, self::EXP_OR, true);
+        $this->where($columnName, $operator, $value, self::EXP_OR, true);
 
         return $this;
     }
@@ -141,14 +141,14 @@ class WhereHandler
      * Ajoute une condition between à la requête.
      * Si la valeur du champ est compris entre 2 valeurs.
      *
-     * @param string         $column Nom de la colonne.
-     * @param numeric|string $min    Valeur minimum ou égale.
-     * @param numeric|string $max    Valeur maximum ou égale.
-     * @param string         $bool   Porte logique de la condition (and|or).
-     * @param bool           $not    Inverse la condition.
+     * @param string         $columnName Nom de la colonne.
+     * @param numeric|string $min        Valeur minimum ou égale.
+     * @param numeric|string $max        Valeur maximum ou égale.
+     * @param string         $bool       Porte logique de la condition (and|or).
+     * @param bool           $not        Inverse la condition.
      */
     public function between(
-        string $column,
+        string $columnName,
         $min,
         $max,
         string $bool = self::EXP_AND,
@@ -158,7 +158,7 @@ class WhereHandler
         $type      = __FUNCTION__;
         $value     = [ 'min' => $min, 'max' => $max ];
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
 
         return $this;
     }
@@ -169,9 +169,9 @@ class WhereHandler
      * @param numeric|string $min Valeur minimum ou égale.
      * @param numeric|string $max Valeur maximum ou égale.
      */
-    public function notBetween(string $column, $min, $max): self
+    public function notBetween(string $columnName, $min, $max): self
     {
-        $this->between($column, $min, $max, self::EXP_AND, true);
+        $this->between($columnName, $min, $max, self::EXP_AND, true);
 
         return $this;
     }
@@ -182,9 +182,9 @@ class WhereHandler
      * @param numeric|string $min Valeur minimum ou égale.
      * @param numeric|string $max Valeur maximum ou égale.
      */
-    public function orBetween(string $column, $min, $max): self
+    public function orBetween(string $columnName, $min, $max): self
     {
-        $this->between($column, $min, $max, self::EXP_OR);
+        $this->between($columnName, $min, $max, self::EXP_OR);
 
         return $this;
     }
@@ -195,9 +195,9 @@ class WhereHandler
      * @param numeric|string $min Valeur minimum ou égale.
      * @param numeric|string $max Valeur maximum ou égale.
      */
-    public function orNotBetween(string $column, $min, $max): self
+    public function orNotBetween(string $columnName, $min, $max): self
     {
-        $this->between($column, $min, $max, self::EXP_OR, true);
+        $this->between($columnName, $min, $max, self::EXP_OR, true);
 
         return $this;
     }
@@ -206,13 +206,13 @@ class WhereHandler
      * Ajoute une condition in à la requête.
      * Si la valeur du champs est contenu dans une liste.
      *
-     * @param string $column Nom de la colonne.
-     * @param array  $value  Valeurs à tester.
-     * @param string $bool   Porte logique de la condition (and|or).
-     * @param bool   $not    Inverse la condition.
+     * @param string $columnName Nom de la colonne.
+     * @param array  $value      Valeurs à tester.
+     * @param string $bool       Porte logique de la condition (and|or).
+     * @param bool   $not        Inverse la condition.
      */
     public function in(
-        string $column,
+        string $columnName,
         array $value,
         string $bool = self::EXP_AND,
         bool $not = false
@@ -220,7 +220,7 @@ class WhereHandler
         $condition = 'in';
         $type      = __FUNCTION__;
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
 
         return $this;
     }
@@ -228,9 +228,9 @@ class WhereHandler
     /**
      * Alias inverse de la fonction in().
      */
-    public function notIn(string $column, array $value): self
+    public function notIn(string $columnName, array $value): self
     {
-        $this->in($column, $value, self::EXP_AND, true);
+        $this->in($columnName, $value, self::EXP_AND, true);
 
         return $this;
     }
@@ -238,9 +238,9 @@ class WhereHandler
     /**
      * Alias avec la porte logique 'OR' de la fonction in().
      */
-    public function orIn(string $column, array $value): self
+    public function orIn(string $columnName, array $value): self
     {
-        $this->in($column, $value, self::EXP_OR);
+        $this->in($columnName, $value, self::EXP_OR);
 
         return $this;
     }
@@ -248,9 +248,9 @@ class WhereHandler
     /**
      * Alias inverse avec la porte logique 'OR' de la fonction in().
      */
-    public function orNotIn(string $column, array $value): self
+    public function orNotIn(string $columnName, array $value): self
     {
-        $this->in($column, $value, self::EXP_OR, true);
+        $this->in($columnName, $value, self::EXP_OR, true);
 
         return $this;
     }
@@ -259,12 +259,12 @@ class WhereHandler
      * Ajoute une condition isNull à la requête.
      * Si la valeur du champ est strictement égale à null.
      *
-     * @param string $column Nom de la colonne.
-     * @param string $bool   Porte logique de la condition (and|or).
-     * @param bool   $not    Inverse la condition.
+     * @param string $columnName Nom de la colonne.
+     * @param string $bool       Porte logique de la condition (and|or).
+     * @param bool   $not        Inverse la condition.
      */
     public function isNull(
-        string $column,
+        string $columnName,
         string $bool = self::EXP_AND,
         bool $not = false
     ): self {
@@ -272,7 +272,7 @@ class WhereHandler
         $type      = __FUNCTION__;
         $value     = null;
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
 
         return $this;
     }
@@ -280,9 +280,9 @@ class WhereHandler
     /**
      * Alias inverse de la fonction isNull().
      */
-    public function isNotNull(string $column): self
+    public function isNotNull(string $columnName): self
     {
-        $this->isNull($column, self::EXP_AND, true);
+        $this->isNull($columnName, self::EXP_AND, true);
 
         return $this;
     }
@@ -290,9 +290,9 @@ class WhereHandler
     /**
      * Alias avec la porte logique 'OR' de la fonction isNull().
      */
-    public function orIsNull(string $column): self
+    public function orIsNull(string $columnName): self
     {
-        $this->isNull($column, self::EXP_OR);
+        $this->isNull($columnName, self::EXP_OR);
 
         return $this;
     }
@@ -300,9 +300,9 @@ class WhereHandler
     /**
      * Alias inverse avec la porte logique 'OR' de la fonction isNull()
      */
-    public function orIsNotNull(string $column): self
+    public function orIsNotNull(string $columnName): self
     {
-        $this->isNull($column, self::EXP_OR, true);
+        $this->isNull($columnName, self::EXP_OR, true);
 
         return $this;
     }
@@ -310,13 +310,13 @@ class WhereHandler
     /**
      * Ajoute une condition avec une expression régulière à la requête.
      *
-     * @param string $column Nom de la colonne.
-     * @param string $value  Expression régulière.
-     * @param string $bool   Porte logique de la condition (and|or).
-     * @param bool   $not    Inverse la condition.
+     * @param string $columnName Nom de la colonne.
+     * @param string $value      Expression régulière.
+     * @param string $bool       Porte logique de la condition (and|or).
+     * @param bool   $not        Inverse la condition.
      */
     public function regex(
-        string $column,
+        string $columnName,
         string $value,
         string $bool = self::EXP_AND,
         bool $not = false
@@ -324,7 +324,7 @@ class WhereHandler
         $condition = 'regex';
         $type      = __FUNCTION__;
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
 
         return $this;
     }
@@ -332,9 +332,9 @@ class WhereHandler
     /**
      *  Alias inverse de la fonction regex().
      */
-    public function notRegex(string $column, string $pattern): self
+    public function notRegex(string $columnName, string $pattern): self
     {
-        $this->regex($column, $pattern, self::EXP_AND, true);
+        $this->regex($columnName, $pattern, self::EXP_AND, true);
 
         return $this;
     }
@@ -342,9 +342,9 @@ class WhereHandler
     /**
      *  Alias avec la porte logique 'OR' de la fonction regex().
      */
-    public function orRegex(string $column, string $pattern): self
+    public function orRegex(string $columnName, string $pattern): self
     {
-        $this->regex($column, $pattern, self::EXP_OR);
+        $this->regex($columnName, $pattern, self::EXP_OR);
 
         return $this;
     }
@@ -352,9 +352,9 @@ class WhereHandler
     /**
      *  Alias inverse avec la porte logique 'OR' de la fonction regex()
      */
-    public function orNotRegex(string $column, string $pattern): self
+    public function orNotRegex(string $columnName, string $pattern): self
     {
-        $this->regex($column, $pattern, self::EXP_OR, true);
+        $this->regex($columnName, $pattern, self::EXP_OR, true);
 
         return $this;
     }
@@ -371,13 +371,13 @@ class WhereHandler
         call_user_func_array($callable, [ &$where ]);
 
         $this->where[] = [
-            'type'      => __FUNCTION__,
-            'column'    => '',
-            'columns'   => $where->getColumns(),
-            'condition' => '',
-            'value'     => $where,
-            'bool'      => $bool,
-            'not'       => $not
+            'type'        => __FUNCTION__,
+            'columnName'  => '',
+            'columnNames' => $where->getColumnNames(),
+            'condition'   => '',
+            'value'       => $where,
+            'bool'        => $bool,
+            'not'         => $not
         ];
     }
 
@@ -414,7 +414,7 @@ class WhereHandler
     /**
      * Ajoute une condition like pour la requête.
      *
-     * @param string $column
+     * @param string $columnName
      * @param string $operator
      * @param string $pattern
      * @param string $bool
@@ -423,7 +423,7 @@ class WhereHandler
      * @return void
      */
     protected function like(
-        string $column,
+        string $columnName,
         string $operator,
         string $pattern,
         string $bool = self::EXP_AND,
@@ -443,7 +443,7 @@ class WhereHandler
         $type      = __FUNCTION__;
         $condition = 'regex';
 
-        $this->where[] = compact('bool', 'column', 'condition', 'not', 'type', 'value');
+        $this->where[] = compact('bool', 'columnName', 'condition', 'not', 'type', 'value');
     }
 
     /**

--- a/src/WhereHandler.php
+++ b/src/WhereHandler.php
@@ -52,7 +52,9 @@ class WhereHandler
     /**
      * Les conditions à exécuter.
      *
-     * @var WhereToArray[]
+     * @var array
+     *
+     * @phpstan-var WhereToArray[]
      */
     protected $where = [];
 

--- a/src/WhereHandler.php
+++ b/src/WhereHandler.php
@@ -17,6 +17,17 @@ use Queryflatfile\Exception\Query\QueryException;
  * Pattern fluent pour la création des clauses (conditions) de manipulation des données.
  *
  * @author Mathieu NOËL <mathieu@soosyze.com>
+ *
+ * @phpstan-type Between array{min: numeric|string, max: numeric|string}
+ * @phpstan-type WhereToArray array{
+ *      bool: string,
+ *      column: string,
+ *      columns?: array,
+ *      condition: string,
+ *      not: bool,
+ *      type: string,
+ *      value: array|Between|null|scalar|Where,
+ * }
  */
 class WhereHandler
 {
@@ -41,7 +52,7 @@ class WhereHandler
     /**
      * Les conditions à exécuter.
      *
-     * @var array
+     * @var WhereToArray[]
      */
     protected $where = [];
 
@@ -358,11 +369,13 @@ class WhereHandler
         call_user_func_array($callable, [ &$where ]);
 
         $this->where[] = [
-            'type'   => __FUNCTION__,
-            'column' => $where->getColumns(),
-            'value'  => $where,
-            'bool'   => $bool,
-            'not'    => $not
+            'type'      => __FUNCTION__,
+            'column'    => '',
+            'columns'   => $where->getColumns(),
+            'condition' => '',
+            'value'     => $where,
+            'bool'      => $bool,
+            'not'       => $not
         ];
     }
 

--- a/tests/unit/RequestTest.php
+++ b/tests/unit/RequestTest.php
@@ -563,6 +563,22 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testWhereEqualsNull(): void
+    {
+        $data = $this->request
+            ->from('user')
+            ->where('firstname', '===', null);
+
+        self::assertEquals(
+            'SELECT * FROM user WHERE firstname === null;',
+            (string) $data
+        );
+        self::assertEquals(
+            [ 'id' => 6, 'name' => 'ROBERT', 'firstname' => null ],
+            $data->fetch()
+        );
+    }
+
     public function testWhereIsNotNull(): void
     {
         $data = $this->request
@@ -676,7 +692,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         // LIKE
         yield [
             'like', 'DUP%',
-            'SELECT id, name FROM user WHERE name LIKE /^DUP.*$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^DUP.*$/\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 4, 'name' => 'DUPOND' ]
@@ -684,24 +700,24 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'like', '%TI%',
-            'SELECT id, name FROM user WHERE name LIKE /^.*TI.*$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^.*TI.*$/\';',
             [
                 [ 'id' => 2, 'name' => 'MARTIN' ]
             ]
         ];
         yield [
             'like', 'OND',
-            'SELECT id, name FROM user WHERE name LIKE /^OND$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^OND$/\';',
             []
         ];
         yield [
             'like', 'OND%',
-            'SELECT id, name FROM user WHERE name LIKE /^OND.*$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^OND.*$/\';',
             []
         ];
         yield [
             'like', '%OND',
-            'SELECT id, name FROM user WHERE name LIKE /^.*OND$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^.*OND$/\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 4, 'name' => 'DUPOND' ]
@@ -709,7 +725,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'like', '%OND%',
-            'SELECT id, name FROM user WHERE name LIKE /^.*OND.*$/;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^.*OND.*$/\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 4, 'name' => 'DUPOND' ]
@@ -719,7 +735,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         // ILIKE
         yield [
             'ilike', 'Dup%',
-            'SELECT id, name FROM user WHERE name LIKE /^Dup.*$/i;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^Dup.*$/i\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 4, 'name' => 'DUPOND' ]
@@ -727,7 +743,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'ilike', '%OnD',
-            'SELECT id, name FROM user WHERE name LIKE /^.*OnD$/i;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^.*OnD$/i\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 4, 'name' => 'DUPOND' ]
@@ -735,7 +751,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'ilike', '%ti%',
-            'SELECT id, name FROM user WHERE name LIKE /^.*ti.*$/i;',
+            'SELECT id, name FROM user WHERE name LIKE \'/^.*ti.*$/i\';',
             [
                 [ 'id' => 2, 'name' => 'MARTIN' ]
             ]
@@ -744,7 +760,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         // NOT LIKE
         yield [
             'not like', 'DUP%',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^DUP.*$/;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^DUP.*$/\';',
             [
                 [ 'id' => 0, 'name' => 'NOEL' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -754,7 +770,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'not like', '%OND',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^.*OND$/;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^.*OND$/\';',
             [
                 [ 'id' => 0, 'name' => 'NOEL' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -764,7 +780,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'not like', '%E%',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^.*E.*$/;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^.*E.*$/\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -775,7 +791,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         // NOT ILIKE
         yield [
             'not ilike', 'DuP%',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^DuP.*$/i;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^DuP.*$/i\';',
             [
                 [ 'id' => 0, 'name' => 'NOEL' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -785,7 +801,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'not ilike', '%D',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^.*D$/i;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^.*D$/i\';',
             [
                 [ 'id' => 0, 'name' => 'NOEL' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -795,7 +811,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
         ];
         yield [
             'not ilike', '%E%',
-            'SELECT id, name FROM user WHERE name NOT LIKE /^.*E.*$/i;',
+            'SELECT id, name FROM user WHERE name NOT LIKE \'/^.*E.*$/i\';',
             [
                 [ 'id' => 1, 'name' => 'DUPOND' ],
                 [ 'id' => 2, 'name' => 'MARTIN' ],
@@ -810,7 +826,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             ->from('user')
             ->regex('name', '/^D/');
 
-        self::assertEquals('SELECT * FROM user WHERE name REGEX /^D/;', (string) $data);
+        self::assertEquals('SELECT * FROM user WHERE name REGEX \'/^D/\';', (string) $data);
         self::assertEquals(
             [
                 [ 'id' => 1, 'name' => 'DUPOND', 'firstname' => 'Jean' ],
@@ -826,7 +842,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             ->from('user')
             ->notRegex('name', '/^D/');
 
-        self::assertEquals('SELECT * FROM user WHERE name NOT REGEX /^D/;', (string) $data);
+        self::assertEquals('SELECT * FROM user WHERE name NOT REGEX \'/^D/\';', (string) $data);
         self::assertEquals(
             [
                 [ 'id' => 0, 'name' => 'NOEL', 'firstname' => 'Mathieu' ],
@@ -846,7 +862,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             ->orNotRegex('firstname', '/^M/');
 
         self::assertEquals(
-            'SELECT * FROM user WHERE name REGEX /^D/ OR firstname NOT REGEX /^M/;',
+            'SELECT * FROM user WHERE name REGEX \'/^D/\' OR firstname NOT REGEX \'/^M/\';',
             (string) $data
         );
         self::assertEquals(
@@ -867,7 +883,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
             ->orRegex('name', '/^N/');
 
         self::assertEquals(
-            'SELECT * FROM user WHERE name REGEX /^D/ OR name REGEX /^N/;',
+            'SELECT * FROM user WHERE name REGEX \'/^D/\' OR name REGEX \'/^N/\';',
             (string) $data
         );
         self::assertEquals(
@@ -883,7 +899,7 @@ class RequestTest extends \PHPUnit\Framework\TestCase
     public function testWhereRegexExceptionColumns(): void
     {
         $this->expectException(ColumnsNotFoundException::class);
-        $this->expectExceptionMessage('Column foo is absent: SELECT * FROM user WHERE foo REGEX /^D/ LIMIT 1;');
+        $this->expectExceptionMessage('Column foo is absent: SELECT * FROM user WHERE foo REGEX \'/^D/\' LIMIT 1;');
         $this->request
             ->from('user')
             ->regex('foo', '/^D/')

--- a/tests/unit/TableAlterTest.php
+++ b/tests/unit/TableAlterTest.php
@@ -23,7 +23,7 @@ class TableAlterTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals($this->object->getTable()->toArray(), [
             'fields'     => [
-                '0' => [ 'opt' => Field::OPT_DROP ]
+                '0' => [ 'type' => '', 'opt' => Field::OPT_DROP ]
             ],
             'increments' => null
         ]);
@@ -35,7 +35,7 @@ class TableAlterTest extends \PHPUnit\Framework\TestCase
 
         self::assertEquals($this->object->getTable()->toArray(), [
             'fields'     => [
-                '0' => [ 'opt' => Field::OPT_RENAME, 'to' => '1' ]
+                '0' => [ 'type' => '', 'opt' => Field::OPT_RENAME, 'to' => '1' ]
             ],
             'increments' => null
         ]);


### PR DESCRIPTION
Renommer les attribute de méthode `$table` par `$tableName` pour ne pas confondre avec le type `Table`.
Renommer l'attribut `union` par `unions` car il s'agit d'une liste d'unions.
Renommer les attributs contenant des champs par `Field`

Renommage des attributs, variables et méthodes contenant des noms de colonnes sans ambiguïté (ayant un type `string`) par `columnName` ou `columnNames` au pluriel.

Déclaration des type phpstan suivant:
```
/**
 * Between array{min: numeric|string, max: numeric|string}
 * FieldToArray array{
 *      _comment?: string,
 *      default?: null|scalar,
 *      length?: int,
 *      nullable?: bool,
 *      opt?: string,
 *      type: string,
 *      unsigned?: bool,
 * }
 * Join array{type: string, table: string, where: Where}
 * RowData array<string, null|scalar> contient les clé/valeur d'une ligne de données
 * RowValues array<null|scalar> contient les valeur d'une ligne de données
 * TableData RowData[]` contient un ensemble de ligne de données
 * TableToArray array{
 *    fields: array<string, FieldToArray>,
 *    increments?: int|null
 * }
 * Union array{request: RequestInterface, type: string}
 * WhereToArray array{
 *      bool: string,
 *      columnName: string,
 *      columnNames?: array,
 *      condition: string,
 *      not: bool,
 *      type: string,
 *      value: array|Between|null|scalar|Where,
 * }
 * /
```
